### PR TITLE
 Διόρθωση τύπου υπολογισμού ημέρας και προσθήκη περιγραφής για δίσεκτο έτος

### DIFF
--- a/labs/lab03/README.md
+++ b/labs/lab03/README.md
@@ -189,7 +189,12 @@ $$
 \end{matrix}
 $$
 
-$$ IDAY = 365 \cdot YYYY + DD + 31 \cdot (MM - 1) - NMM + \left\lfloor \frac{NYYYY}{4}\right\rfloor - \left\lfloor \frac{3}{4} \cdot \left(\left\lfloor \frac{NYYYY}{100} \right\rfloor + 1\right) \right\rfloor $$
+$$
+IDAY = 365 \cdot YYYY + DD + 31 \cdot (MM - 1) - NMM + \left\lfloor \frac{NYYYY}{4}\right\rfloor - \left\lfloor \frac{3}{4} \cdot \left(\left\lfloor \frac{NYYYY}{100} \right\rfloor + 1\right) \right\rfloor
+$$
+$$ + \left\lfloor \frac{NYYYY}{400} \right\rfloor$$
+
+- **Δίσεκτο Έτος:** Ένα έτος είναι δίσεκτο αν διαιρείται με το 4, **εκτός** εάν διαιρείται και με το 100, **εκτός** αν διαιρείται και με το 400. Ο παραπάνω τύπος υπολογίζει αυτόματα αν το έτος είναι δίσεκτο, χρησιμοποιώντας το $\left\lfloor \frac{NYYYY}{4}\right\rfloor$, $\left\lfloor \frac{NYYYY}{100} \right\rfloor$, και $\left\lfloor \frac{NYYYY}{400}\right\rfloor$.
 
 Για τον υπολογισμό της ημέρας, αν:
 


### PR DESCRIPTION
## Περιγραφή
Αυτό το pull request ενημερώνει τον τύπο υπολογισμού της ημέρας για να λαμβάνει υπόψη τα δίσεκτα έτη με ακρίβεια και προσθέτει περιγραφή για τον υπολογισμό δίσεκτων ετών. Η αρχική έκδοση του τύπου δεν περιλάμβανε τον όρο για τα έτη που διαιρούνται με το 400, γεγονός που μπορεί να επηρέαζε τον υπολογισμό για κάποιες ημερομηνίες.

## Αλλαγές στον Τύπο
Ο αρχικός τύπος:
```md
$$
IDAY = 365 \cdot YYYY + DD + 31 \cdot (MM - 1) - NMM + \left\lfloor \frac{NYYYY}{4}\right\rfloor - \left\lfloor \frac{3}{4} \cdot \left(\left\lfloor \frac{NYYYY}{100} \right\rfloor + 1\right) \right\rfloor
$$
```
ενημερώθηκε ώστε να περιλαμβάνει τον όρο $\left\lfloor \frac{NYYYY}{400} \right\rfloor$ για τα έτη που είναι δίσεκτα μόνο αν διαιρούνται με το 400:
```md
$$
IDAY = 365 \cdot YYYY + DD + 31 \cdot (MM - 1) - NMM + \left\lfloor \frac{NYYYY}{4}\right\rfloor - \left\lfloor \frac{3}{4} \cdot \left(\left\lfloor \frac{NYYYY}{100} \right\rfloor + 1\right) \right\rfloor 
$$
$$
+ \left\lfloor \frac{NYYYY}{400} \right\rfloor
$$
```

## Προσθήκη Περιγραφής Δίσεκτου Έτους

Προστέθηκε η ακόλουθη περιγραφή για τον υπολογισμό δίσεκτου έτους:

- **Δίσεκτο Έτος:** Ένα έτος είναι δίσεκτο αν διαιρείται με το 4, **εκτός** εάν διαιρείται και με το 100, **εκτός** αν διαιρείται και με το 400. 
 
Για παράδειγμα:

- Το έτος **2000** είναι δίσεκτο (διαιρείται με 4, 100 και 400).
- Το έτος **1900** δεν είναι δίσεκτο (διαιρείται με το 100 αλλά όχι με το 400).

Ο παραπάνω τύπος υπολογίζει αυτόματα αν το έτος είναι δίσεκτο, χρησιμοποιώντας το $\left\lfloor \frac{NYYYY}{4}\right\rfloor$, $\left\lfloor \frac{NYYYY}{100} \right\rfloor$, και $\left\lfloor \frac{NYYYY}{400}\right\rfloor$.